### PR TITLE
DISC-1314 - Updates User's WithheldInCountries to be type []string

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-version=0.2.3
+version=0.2.4
 
 .PHONY: all
 

--- a/model.go
+++ b/model.go
@@ -239,7 +239,7 @@ type User struct {
 	URL                            string   `json:"url"`
 	UTCOffset                      int      `json:"utc_offset"`
 	Verified                       bool     `json:"verified"`
-	WithheldInCountries            string   `json:"withheld_in_countries"`
+	WithheldInCountries            []string `json:"withheld_in_countries"`
 	WithheldScope                  string   `json:"withheld_scope"`
 }
 


### PR DESCRIPTION
- We've started to notice that Twitter requests have been failing.
- Based on PaperTrail logs, the error is related to Marshall failing to parse the response since it expects a type []string for withheld_in_countries on the User model.
- We speculate that this was an inconsistency Twitter has had with their live API, and we coded it as such (ie to expect a string) and now they've finally fixed/updated it.
- A more thorough write-up for our incident can be found here:
https://www.notion.so/crowdriff/Twitter-Ingestion-is-Failing-0b42a37f5f7441ffb073652458287763